### PR TITLE
build: make install to DESTDIR

### DIFF
--- a/makefile.in
+++ b/makefile.in
@@ -179,11 +179,11 @@ libliquidusrp.so: $(library_objs)
 
 install:
 	@echo "installing..."
-	mkdir -p $(exec_prefix)/lib
-	install -m 644 -p $(SHARED_LIB) libliquidusrp.a $(exec_prefix)/lib
-	mkdir -p $(prefix)/include
-	mkdir -p $(prefix)/include/liquid
-	install -m 644 -p $(addprefix include/,$(headers_install)) $(prefix)/include/liquid
+	mkdir -p $(DESTDIR)$(exec_prefix)/lib
+	install -m 644 -p $(SHARED_LIB) libliquidusrp.a $(DESTDIR)$(exec_prefix)/lib
+	mkdir -p $(DESTDIR)$(prefix)/include
+	mkdir -p $(DESTDIR)$(prefix)/include/liquid
+	install -m 644 -p $(addprefix include/,$(headers_install)) $(DESTDIR)$(prefix)/include/liquid
 	@echo ""
 	@echo "---------------------------------------------------------"
 	@echo "  liquid-usrp was successfully installed.     "
@@ -192,7 +192,7 @@ install:
 	@echo "  libraries by running 'ldconfig' to make the shared"
 	@echo "  object available.  You might also need to modify your"
 	@echo "  LD_LIBRARY_PATH environment variable to include the"
-	@echo "  directory $(exec_prefix)"
+	@echo "  directory $(DESTDIR)$(exec_prefix)"
 	@echo "---------------------------------------------------------"
 	@echo ""
 
@@ -202,9 +202,9 @@ install:
 
 uninstall:
 	@echo "uninstalling..."
-	$(RM) $(addprefix $(prefix)/include/liquid/, $(headers_install))
-	$(RM) $(exec_prefix)/lib/libliquidusrp.a
-	$(RM) $(exec_prefix)/lib/$(SHARED_LIB)
+	$(RM) $(addprefix $(DESTDIR)$(prefix)/include/liquid/, $(headers_install))
+	$(RM) $(DESTDIR)$(exec_prefix)/lib/libliquidusrp.a
+	$(RM) $(DESTDIR)$(exec_prefix)/lib/$(SHARED_LIB)
 	@echo "done."
 
 


### PR DESCRIPTION
Look for DESTDIR argument to install to nonstandard targets, e.g., for cross compiling and installing to sysroots or mounted devices.